### PR TITLE
feat: add option to show commit messages for HEAD files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ as well as the [consult](https://github.com/minad/consult) package for navigatio
 - 🔄 Smart preview window management (no more duplicate preview windows!
 - 🧵 Narrow to the right type of files with the `consult-narrow-key` (`>` by
   default):
-  * `h` for modified in HEAD
-  * `a` added (untracked) files
-  * `l` modified locally
-  * `c` staged for commit.
+  - `h` for modified in HEAD
+  - `a` added (untracked) files
+  - `l` modified locally
+  - `c` staged for commit.
 
 > [!CAUTION]
 > This only works with Git repositories and no other version control systems.
@@ -88,11 +88,27 @@ branch heads:
 
 This configuration includes:
 
-* Modified files (tracked files with changes)
-* Added files (new untracked files)
-* Staged files (changes ready for commit)
+- Modified files (tracked files with changes)
+- Added files (new untracked files)
+- Staged files (changes ready for commit)
 
 But it excludes files modified in branch heads.
+
+### Display Git Commit Messages when showing the HEAD files
+
+You can control whether to show commit message descriptions for files modified
+in HEAD with the `consult-vc-modified-files-show-description` customization
+option:
+
+```elisp
+(setq consult-vc-modified-files-show-description t)  ;; Show descriptions (default is nil)
+```
+
+When enabled, this option displays the commit message next to each file modified
+in the HEAD commit, providing more context about the changes.
+
+- When `t`: Shows commit message descriptions for HEAD files
+- When `nil`: Shows only the filenames without descriptions
 
 ### Customize Faces
 

--- a/consult-vc-modified-files.el
+++ b/consult-vc-modified-files.el
@@ -35,6 +35,13 @@
 (require 'consult)
 (require 'vc-git)
 
+(defcustom consult-vc-modified-files-show-description nil
+  "Option to control the display of git change description for HEAD files.
+When non-nil, show the description for each file.
+When nil, do not show the description."
+  :type 'boolean
+  :group 'consult-vc-modified)
+
 (defun consult-vc-files--git-preview (command preview-buffer-name &optional args)
   "Create preview function for git files using COMMAND.
 PREVIEW-BUFFER-NAME is the name for the preview buffer.
@@ -105,7 +112,9 @@ Uses the same buffer management approach as `consult--buffer-preview`."
 ;; Define the specialized versions using the unified function
 (defun consult-vc-modified-files--git-show-preview ()
   "Create preview function for file history, using vc-git for show."
-  (consult-vc-files--git-preview "show" "*git-show-preview*"))
+  (if consult-vc-modified-files-show-description
+      (consult-vc-files--git-preview "show" "*git-show-preview*")
+    (consult-vc-files--git-preview "diff" "*git-show-preview*" '("HEAD~"))))
 
 (defun consult-vc-modified-files--git-diff-preview ()
   "Create preview function for modified files.

--- a/consult-vc-modified-files.el
+++ b/consult-vc-modified-files.el
@@ -5,7 +5,7 @@
 ;; Author: Chmouel Boudjnah <chmouel@chmouel.com>
 ;; Keywords: vc, convenience
 ;; Created: 2023
-;; Version: 0.0.8
+;; Version: 0.0.9
 ;; Package-Requires: ((emacs "28.1") (consult "0.9"))
 ;; Keywords: convenience
 ;; Homepage: https://github.com/chmouel/consult-vc-modified-files


### PR DESCRIPTION
Added a new customization option
`consult-vc-modified-files-show-description`
to control the display of commit message descriptions for files modified
in
HEAD. When enabled, this option shows the commit message next to each
file
modified in the HEAD commit, providing more context about the changes.

- Updated README.md to document the new option.
- Modified `consult-vc-modified-files.el` to include the new option and
  adjust the preview function accordingly.

Fixes #4
